### PR TITLE
feat: add dynamic interface management to handle network disconnects

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package zeroconf
 import (
 	"context"
 	"fmt"
+	"log"
 	"math/rand"
 	"net"
 	"reflect"
@@ -204,21 +205,25 @@ func newClient(opts clientOpts) (*Client, error) {
 
 	// IPv4 interfaces
 	var ipv4conn api.PacketConn
+	var err4 error
 	if (opts.listenOn & IPv4) > 0 {
-		var err error
-		ipv4conn, err = factory.CreateIPv4Conn(ifaces)
-		if err != nil {
-			return nil, err
+		ipv4conn, err4 = factory.CreateIPv4Conn(ifaces)
+		if err4 != nil {
+			log.Printf("[zeroconf] no suitable IPv4 interface: %s", err4.Error())
 		}
 	}
 	// IPv6 interfaces
 	var ipv6conn api.PacketConn
+	var err6 error
 	if (opts.listenOn & IPv6) > 0 {
-		var err error
-		ipv6conn, err = factory.CreateIPv6Conn(ifaces)
-		if err != nil {
-			return nil, err
+		ipv6conn, err6 = factory.CreateIPv6Conn(ifaces)
+		if err6 != nil {
+			log.Printf("[zeroconf] no suitable IPv6 interface: %s", err6.Error())
 		}
+	}
+
+	if err4 != nil && err6 != nil {
+		return nil, fmt.Errorf("no supported interface")
 	}
 
 	return &Client{

--- a/client.go
+++ b/client.go
@@ -32,13 +32,16 @@ var initialQueryInterval = 4 * time.Second
 type Client struct {
 	ipv4conn api.PacketConn
 	ipv6conn api.PacketConn
-	ifaces   []net.Interface
+	ipv4Mgr  *InterfaceManager
+	ipv6Mgr  *InterfaceManager
+	provider api.InterfaceProvider
 }
 
 type clientOpts struct {
 	listenOn    IPType
 	ifaces      []net.Interface
 	connFactory api.ConnectionFactory
+	provider    api.InterfaceProvider
 }
 
 // ClientOption fills the option struct to configure intefaces, etc.
@@ -67,6 +70,14 @@ func SelectIfaces(ifaces []net.Interface) ClientOption {
 func WithClientConnFactory(factory api.ConnectionFactory) ClientOption {
 	return func(o *clientOpts) {
 		o.connFactory = factory
+	}
+}
+
+// WithClientInterfaceProvider sets a custom interface provider for the client.
+// This is primarily useful for testing with mock interface lists.
+func WithClientInterfaceProvider(provider api.InterfaceProvider) ClientOption {
+	return func(o *clientOpts) {
+		o.provider = provider
 	}
 }
 
@@ -119,7 +130,19 @@ func applyOpts(options ...ClientOption) clientOpts {
 }
 
 func (c *Client) run(ctx context.Context, params *lookupParams) error {
+	// Run immediate sync on startup to catch any interfaces that changed
+	// between client creation and run()
+	c.syncInterfaces()
+
 	ctx, cancel := context.WithCancel(ctx)
+
+	// Start interface sync in background
+	syncDone := make(chan struct{})
+	go func() {
+		defer close(syncDone)
+		c.runInterfaceSync(ctx)
+	}()
+
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
@@ -131,6 +154,7 @@ func (c *Client) run(ctx context.Context, params *lookupParams) error {
 	err := c.periodicQuery(ctx, params)
 	cancel()
 	<-done
+	<-syncDone
 	return err
 }
 
@@ -147,15 +171,36 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 
 // newClient is the internal constructor that takes pre-applied options.
 func newClient(opts clientOpts) (*Client, error) {
+	// Get interface provider (use default if not injected for testing)
+	provider := opts.provider
+	if provider == nil {
+		provider = NewInterfaceProvider()
+	}
+
 	ifaces := opts.ifaces
-	if len(ifaces) == 0 {
-		ifaces = NewInterfaceProvider().MulticastInterfaces()
+	var requested []string
+
+	// Determine mode based on whether interfaces were explicitly provided
+	if len(ifaces) > 0 {
+		// Explicit mode: extract names for the manager
+		requested = make([]string, len(ifaces))
+		for i, iface := range ifaces {
+			requested[i] = iface.Name
+		}
+	} else {
+		// Dynamic mode: get current interfaces
+		ifaces = provider.MulticastInterfaces()
 	}
 
 	factory := opts.connFactory
 	if factory == nil {
 		factory = NewConnectionFactory()
 	}
+
+	// Create SEPARATE managers for IPv4 and IPv6.
+	// This ensures IPv6 failures don't affect IPv4 (and vice versa).
+	ipv4Mgr := NewInterfaceManager(ifaces, requested)
+	ipv6Mgr := NewInterfaceManager(ifaces, requested)
 
 	// IPv4 interfaces
 	var ipv4conn api.PacketConn
@@ -179,7 +224,9 @@ func newClient(opts clientOpts) (*Client, error) {
 	return &Client{
 		ipv4conn: ipv4conn,
 		ipv6conn: ipv6conn,
-		ifaces:   ifaces,
+		ipv4Mgr:  ipv4Mgr,
+		ipv6Mgr:  ipv6Mgr,
+		provider: provider,
 	}, nil
 }
 
@@ -450,26 +497,74 @@ func (c *Client) query(params *lookupParams) error {
 	return c.sendQuery(m)
 }
 
-// Pack the dns.Msg and write to available connections (multicast)
+// sendQuery packs the dns.Msg and writes to available connections (multicast).
+//
+// THE CRITICAL FIX: Dynamic iteration using ActiveIndices().
+// Gets a fresh snapshot of active indices on each call. The snapshot may become
+// stale during iteration (race with syncInterfaces), but this is BENIGN because:
+//   - Sends to removed indices fail immediately
+//   - MarkFailed is idempotent (safe to call on already-removed index)
+//   - New indices are picked up on the next sendQuery call
 func (c *Client) sendQuery(msg *dns.Msg) error {
 	buf, err := msg.Pack()
 	if err != nil {
 		return err
 	}
 
-	// Send to all interfaces via IPv4
+	// IPv4: iterate over CURRENT active indices
 	if c.ipv4conn != nil {
-		for _, iface := range c.ifaces {
-			_, _ = c.ipv4conn.WriteTo(buf, iface.Index, ipv4Addr)
+		for _, idx := range c.ipv4Mgr.ActiveIndices() {
+			if _, err := c.ipv4conn.WriteTo(buf, idx, ipv4Addr); err != nil {
+				c.ipv4Mgr.MarkFailed(idx, err)
+			}
 		}
 	}
 
-	// Send to all interfaces via IPv6
+	// IPv6: same pattern, separate manager
 	if c.ipv6conn != nil {
-		for _, iface := range c.ifaces {
-			_, _ = c.ipv6conn.WriteTo(buf, iface.Index, ipv6Addr)
+		for _, idx := range c.ipv6Mgr.ActiveIndices() {
+			if _, err := c.ipv6conn.WriteTo(buf, idx, ipv6Addr); err != nil {
+				c.ipv6Mgr.MarkFailed(idx, err)
+			}
 		}
 	}
 
 	return nil
+}
+
+// runInterfaceSync periodically polls for interface changes.
+func (c *Client) runInterfaceSync(ctx context.Context) {
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.syncInterfaces()
+		}
+	}
+}
+
+// syncInterfaces polls for interface changes and recovers interfaces.
+func (c *Client) syncInterfaces() {
+	current := c.provider.MulticastInterfaces()
+
+	// Helper to sync a single manager
+	syncManager := func(mgr *InterfaceManager, conn api.PacketConn, groupIP net.IP) {
+		if conn == nil || mgr == nil {
+			return
+		}
+		for _, iface := range mgr.Sync(current) {
+			if err := conn.JoinGroup(&iface, &net.UDPAddr{IP: groupIP}); err != nil {
+				mgr.SetBackoff(iface.Name)
+			} else {
+				mgr.Activate(iface)
+			}
+		}
+	}
+
+	syncManager(c.ipv4Mgr, c.ipv4conn, mdnsGroupIPv4)
+	syncManager(c.ipv6Mgr, c.ipv6conn, mdnsGroupIPv6)
 }

--- a/client_unit_test.go
+++ b/client_unit_test.go
@@ -265,6 +265,73 @@ func TestClient_Shutdown_ClosesConnections(t *testing.T) {
 	c.shutdown()
 }
 
+// TestClient_SyncInterfaces_JoinGroupSuccessActivates verifies syncInterfaces joins and activates.
+func TestClient_SyncInterfaces_JoinGroupSuccessActivates(t *testing.T) {
+	mockIPv4 := mocks.NewMockPacketConn(t)
+	mockProvider := mocks.NewMockInterfaceProvider(t)
+
+	iface := net.Interface{Index: 2, Name: "wlan0"}
+
+	mockProvider.EXPECT().MulticastInterfaces().Return([]net.Interface{iface}).Once()
+	mockIPv4.EXPECT().JoinGroup(mock.AnythingOfType("*net.Interface"), mock.Anything).RunAndReturn(
+		func(ifi *net.Interface, group net.Addr) error {
+			if ifi == nil || ifi.Index != iface.Index || ifi.Name != iface.Name {
+				t.Errorf("expected JoinGroup on %+v, got %+v", iface, ifi)
+			}
+			udpAddr, ok := group.(*net.UDPAddr)
+			if !ok || udpAddr == nil || !udpAddr.IP.Equal(mdnsGroupIPv4) {
+				t.Errorf("expected IPv4 group %v, got %v", mdnsGroupIPv4, group)
+			}
+			return nil
+		}).Once()
+
+	c := &Client{
+		ipv4conn: mockIPv4,
+		ipv4Mgr:  NewInterfaceManager(nil, nil),
+		ipv6Mgr:  NewInterfaceManager(nil, nil),
+		provider: mockProvider,
+	}
+
+	c.syncInterfaces()
+
+	indices := c.ipv4Mgr.ActiveIndices()
+	if len(indices) != 1 || indices[0] != iface.Index {
+		t.Errorf("expected active indices [2], got %v", indices)
+	}
+}
+
+// TestClient_SyncInterfaces_JoinGroupFailureSetsBackoff verifies JoinGroup failure triggers backoff.
+func TestClient_SyncInterfaces_JoinGroupFailureSetsBackoff(t *testing.T) {
+	mockIPv6 := mocks.NewMockPacketConn(t)
+	mockProvider := mocks.NewMockInterfaceProvider(t)
+
+	iface := net.Interface{Index: 3, Name: "eth0"}
+
+	mockProvider.EXPECT().MulticastInterfaces().Return([]net.Interface{iface}).Once()
+	mockIPv6.EXPECT().JoinGroup(mock.AnythingOfType("*net.Interface"), mock.Anything).Return(syscall.ENETDOWN).Once()
+
+	c := &Client{
+		ipv6conn: mockIPv6,
+		ipv4Mgr:  NewInterfaceManager(nil, nil),
+		ipv6Mgr:  NewInterfaceManager(nil, nil),
+		provider: mockProvider,
+	}
+
+	c.syncInterfaces()
+
+	indices := c.ipv6Mgr.ActiveIndices()
+	if len(indices) != 0 {
+		t.Errorf("expected no active indices after JoinGroup failure, got %v", indices)
+	}
+
+	c.ipv6Mgr.mu.RLock()
+	_, hasFailure := c.ipv6Mgr.failures[iface.Name]
+	c.ipv6Mgr.mu.RUnlock()
+	if !hasFailure {
+		t.Errorf("expected backoff failure state for %s", iface.Name)
+	}
+}
+
 // TestClientConfig verifies client configuration options
 func TestClientConfig(t *testing.T) {
 	t.Run("default options", func(t *testing.T) {

--- a/client_unit_test.go
+++ b/client_unit_test.go
@@ -27,6 +27,76 @@ func testClient(ipv4conn, ipv6conn api.PacketConn, ifaces []net.Interface) *Clie
 	}
 }
 
+func TestClient_NewClient_IPv4AndIPv6Error(t *testing.T) {
+	ifaces := []net.Interface{{Index: 1, Name: "eth0"}}
+
+	mockFactory := mocks.NewMockConnectionFactory(t)
+	mockIPv4 := mocks.NewMockPacketConn(t)
+
+	mockFactory.EXPECT().CreateIPv4Conn(ifaces).Return(mockIPv4, nil).Once()
+	mockFactory.EXPECT().CreateIPv6Conn(ifaces).Return(nil, errors.New("IPv6 unavailable")).Once()
+
+	cl, err := newClient(applyOpts(
+		SelectIPTraffic(IPv4AndIPv6),
+		SelectIfaces(ifaces),
+		WithClientConnFactory(mockFactory),
+	))
+	if err != nil {
+		t.Fatalf("newClient failed: %v", err)
+	}
+	if cl.ipv4conn != mockIPv4 {
+		t.Fatalf("expected IPv4 connection to be set")
+	}
+	if cl.ipv6conn != nil {
+		t.Fatalf("expected IPv6 connection to be nil")
+	}
+}
+
+func TestClient_NewClient_IPv6AndIPv4Error(t *testing.T) {
+	ifaces := []net.Interface{{Index: 1, Name: "eth0"}}
+
+	mockFactory := mocks.NewMockConnectionFactory(t)
+	mockIPv6 := mocks.NewMockPacketConn(t)
+
+	mockFactory.EXPECT().CreateIPv4Conn(ifaces).Return(nil, errors.New("IPv4 unavailable")).Once()
+	mockFactory.EXPECT().CreateIPv6Conn(ifaces).Return(mockIPv6, nil).Once()
+
+	cl, err := newClient(applyOpts(
+		SelectIPTraffic(IPv4AndIPv6),
+		SelectIfaces(ifaces),
+		WithClientConnFactory(mockFactory),
+	))
+	if err != nil {
+		t.Fatalf("newClient failed: %v", err)
+	}
+	if cl.ipv4conn != nil {
+		t.Fatalf("expected IPv4 connection to be nil")
+	}
+	if cl.ipv6conn != mockIPv6 {
+		t.Fatalf("expected IPv6 connection to be set")
+	}
+}
+
+func TestClient_NewClient_IPv4ErrorAndIPv6Error(t *testing.T) {
+	ifaces := []net.Interface{{Index: 1, Name: "eth0"}}
+
+	mockFactory := mocks.NewMockConnectionFactory(t)
+	mockFactory.EXPECT().CreateIPv4Conn(ifaces).Return(nil, errors.New("IPv4 unavailable")).Once()
+	mockFactory.EXPECT().CreateIPv6Conn(ifaces).Return(nil, errors.New("IPv6 unavailable")).Once()
+
+	cl, err := newClient(applyOpts(
+		SelectIPTraffic(IPv4AndIPv6),
+		SelectIfaces(ifaces),
+		WithClientConnFactory(mockFactory),
+	))
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if cl != nil {
+		t.Fatalf("expected client to be nil on error")
+	}
+}
+
 // TestClient_InterfaceDisconnect_StopsSendingToFailedInterface is the key integration test
 // that verifies the fix for the original issue: when an interface disconnects, we should
 // stop sending to it rather than generating infinite warning logs.

--- a/client_unit_test.go
+++ b/client_unit_test.go
@@ -5,30 +5,176 @@ import (
 	"errors"
 	"net"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
+	"github.com/enbility/zeroconf/v3/api"
 	"github.com/enbility/zeroconf/v3/mocks"
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/mock"
 )
+
+// testClient creates a Client with mock connections and InterfaceManagers.
+// This is a helper for unit tests that need to create a Client directly.
+func testClient(ipv4conn, ipv6conn api.PacketConn, ifaces []net.Interface) *Client {
+	return &Client{
+		ipv4conn: ipv4conn,
+		ipv6conn: ipv6conn,
+		ipv4Mgr:  NewInterfaceManager(ifaces, nil),
+		ipv6Mgr:  NewInterfaceManager(ifaces, nil),
+		provider: NewInterfaceProvider(),
+	}
+}
+
+// TestClient_InterfaceDisconnect_StopsSendingToFailedInterface is the key integration test
+// that verifies the fix for the original issue: when an interface disconnects, we should
+// stop sending to it rather than generating infinite warning logs.
+//
+// Original issue: Interface disconnects -> WriteTo fails -> code keeps trying -> infinite warnings
+// Expected behavior: Interface disconnects -> WriteTo fails -> interface removed -> no more attempts
+func TestClient_InterfaceDisconnect_StopsSendingToFailedInterface(t *testing.T) {
+	mockIPv4 := mocks.NewMockPacketConn(t)
+
+	// Two interfaces: eth0 (will fail) and wlan0 (stays healthy)
+	ifaces := []net.Interface{
+		{Index: 1, Name: "eth0"},
+		{Index: 2, Name: "wlan0"},
+	}
+
+	// Track calls per interface
+	var mu sync.Mutex
+	callsToEth0 := 0
+	callsToWlan0 := 0
+
+	// eth0 (index 1) will return ENETDOWN error (simulating disconnect)
+	// wlan0 (index 2) will succeed
+	mockIPv4.EXPECT().WriteTo(mock.Anything, mock.AnythingOfType("int"), mock.Anything).RunAndReturn(
+		func(b []byte, ifIndex int, dst net.Addr) (int, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			if ifIndex == 1 {
+				callsToEth0++
+				// Simulate interface gone - this is the error that was causing infinite warnings
+				return 0, syscall.ENETDOWN
+			}
+			callsToWlan0++
+			return len(b), nil
+		}).Maybe()
+
+	c := testClient(mockIPv4, nil, ifaces)
+
+	msg := new(dns.Msg)
+	msg.SetQuestion("_test._tcp.local.", dns.TypePTR)
+
+	// First query: both interfaces should be attempted
+	// eth0 fails with ENETDOWN, wlan0 succeeds
+	_ = c.sendQuery(msg)
+
+	mu.Lock()
+	firstEth0Calls := callsToEth0
+	firstWlan0Calls := callsToWlan0
+	mu.Unlock()
+
+	if firstEth0Calls != 1 {
+		t.Errorf("First query: expected 1 call to eth0, got %d", firstEth0Calls)
+	}
+	if firstWlan0Calls != 1 {
+		t.Errorf("First query: expected 1 call to wlan0, got %d", firstWlan0Calls)
+	}
+
+	// Second query: eth0 should NOT be attempted (it was marked failed)
+	// Only wlan0 should receive the query
+	_ = c.sendQuery(msg)
+
+	mu.Lock()
+	secondEth0Calls := callsToEth0
+	secondWlan0Calls := callsToWlan0
+	mu.Unlock()
+
+	// THE KEY ASSERTION: eth0 should NOT have been called again
+	// This is the fix for the infinite warning issue
+	if secondEth0Calls != 1 {
+		t.Errorf("Second query: expected eth0 to NOT be called again (still 1), got %d calls total", secondEth0Calls)
+	}
+	if secondWlan0Calls != 2 {
+		t.Errorf("Second query: expected wlan0 to be called (now 2), got %d calls total", secondWlan0Calls)
+	}
+
+	// Third query: same behavior - eth0 still excluded
+	_ = c.sendQuery(msg)
+
+	mu.Lock()
+	thirdEth0Calls := callsToEth0
+	thirdWlan0Calls := callsToWlan0
+	mu.Unlock()
+
+	if thirdEth0Calls != 1 {
+		t.Errorf("Third query: eth0 should still be excluded (1 call total), got %d", thirdEth0Calls)
+	}
+	if thirdWlan0Calls != 3 {
+		t.Errorf("Third query: expected wlan0 calls to be 3, got %d", thirdWlan0Calls)
+	}
+
+	t.Logf("SUCCESS: After eth0 disconnect, subsequent queries only went to wlan0")
+	t.Logf("eth0 calls: %d (only the initial failed attempt)", thirdEth0Calls)
+	t.Logf("wlan0 calls: %d (all 3 queries)", thirdWlan0Calls)
+}
+
+// TestClient_AllInterfacesDisconnect_NoInfiniteLoop verifies that if ALL interfaces
+// disconnect, we don't enter an infinite loop - we just have no interfaces to send to.
+func TestClient_AllInterfacesDisconnect_NoInfiniteLoop(t *testing.T) {
+	mockIPv4 := mocks.NewMockPacketConn(t)
+
+	ifaces := []net.Interface{{Index: 1, Name: "eth0"}}
+
+	callCount := 0
+	var mu sync.Mutex
+
+	// Interface always returns ENETDOWN
+	mockIPv4.EXPECT().WriteTo(mock.Anything, mock.AnythingOfType("int"), mock.Anything).RunAndReturn(
+		func(b []byte, ifIndex int, dst net.Addr) (int, error) {
+			mu.Lock()
+			callCount++
+			mu.Unlock()
+			return 0, syscall.ENETDOWN
+		}).Maybe()
+
+	c := testClient(mockIPv4, nil, ifaces)
+
+	msg := new(dns.Msg)
+	msg.SetQuestion("_test._tcp.local.", dns.TypePTR)
+
+	// Send multiple queries
+	for i := 0; i < 10; i++ {
+		_ = c.sendQuery(msg)
+	}
+
+	mu.Lock()
+	finalCount := callCount
+	mu.Unlock()
+
+	// Should only have 1 call - the first one that failed and removed the interface
+	// Without the fix, this would be 10 (one per query, each generating a warning)
+	if finalCount != 1 {
+		t.Errorf("Expected only 1 call to failed interface, got %d (suggests interface not removed)", finalCount)
+	}
+
+	t.Logf("SUCCESS: Only %d call to disconnected interface across 10 queries", finalCount)
+}
 
 // TestClient_SendQuery_WritesToConnections verifies sendQuery writes to both connections
 func TestClient_SendQuery_WritesToConnections(t *testing.T) {
 	mockIPv4 := mocks.NewMockPacketConn(t)
 	mockIPv6 := mocks.NewMockPacketConn(t)
 
-	iface := net.Interface{Index: 1, Name: "eth0"}
+	ifaces := []net.Interface{{Index: 1, Name: "eth0"}}
 
 	// Expect WriteTo to be called on both connections
 	mockIPv4.EXPECT().WriteTo(mock.Anything, 1, mock.Anything).Return(0, nil).Once()
 	mockIPv6.EXPECT().WriteTo(mock.Anything, 1, mock.Anything).Return(0, nil).Once()
 
-	c := &Client{
-		ipv4conn: mockIPv4,
-		ipv6conn: mockIPv6,
-		ifaces:   []net.Interface{iface},
-	}
+	c := testClient(mockIPv4, mockIPv6, ifaces)
 
 	msg := new(dns.Msg)
 	msg.SetQuestion("_test._tcp.local.", dns.TypePTR)
@@ -58,11 +204,7 @@ func TestClient_SendQuery_MultipleInterfaces(t *testing.T) {
 	mockIPv6.EXPECT().WriteTo(mock.Anything, 2, mock.Anything).Return(0, nil).Once()
 	mockIPv6.EXPECT().WriteTo(mock.Anything, 3, mock.Anything).Return(0, nil).Once()
 
-	c := &Client{
-		ipv4conn: mockIPv4,
-		ipv6conn: mockIPv6,
-		ifaces:   ifaces,
-	}
+	c := testClient(mockIPv4, mockIPv6, ifaces)
 
 	msg := new(dns.Msg)
 	msg.SetQuestion("_test._tcp.local.", dns.TypePTR)
@@ -79,11 +221,8 @@ func TestClient_SendQuery_IPv4Only(t *testing.T) {
 
 	mockIPv4.EXPECT().WriteTo(mock.Anything, 1, mock.Anything).Return(0, nil).Once()
 
-	c := &Client{
-		ipv4conn: mockIPv4,
-		ipv6conn: nil,
-		ifaces:   []net.Interface{{Index: 1, Name: "eth0"}},
-	}
+	ifaces := []net.Interface{{Index: 1, Name: "eth0"}}
+	c := testClient(mockIPv4, nil, ifaces)
 
 	msg := new(dns.Msg)
 	msg.SetQuestion("_test._tcp.local.", dns.TypePTR)
@@ -100,11 +239,8 @@ func TestClient_SendQuery_IPv6Only(t *testing.T) {
 
 	mockIPv6.EXPECT().WriteTo(mock.Anything, 1, mock.Anything).Return(0, nil).Once()
 
-	c := &Client{
-		ipv4conn: nil,
-		ipv6conn: mockIPv6,
-		ifaces:   []net.Interface{{Index: 1, Name: "eth0"}},
-	}
+	ifaces := []net.Interface{{Index: 1, Name: "eth0"}}
+	c := testClient(nil, mockIPv6, ifaces)
 
 	msg := new(dns.Msg)
 	msg.SetQuestion("_test._tcp.local.", dns.TypePTR)
@@ -123,11 +259,8 @@ func TestClient_Shutdown_ClosesConnections(t *testing.T) {
 	mockIPv4.EXPECT().Close().Return(nil).Once()
 	mockIPv6.EXPECT().Close().Return(nil).Once()
 
-	c := &Client{
-		ipv4conn: mockIPv4,
-		ipv6conn: mockIPv6,
-		ifaces:   []net.Interface{{Index: 1, Name: "eth0"}},
-	}
+	ifaces := []net.Interface{{Index: 1, Name: "eth0"}}
+	c := testClient(mockIPv4, mockIPv6, ifaces)
 
 	c.shutdown()
 }
@@ -237,11 +370,8 @@ func TestClient_Query_WithInstance(t *testing.T) {
 			return len(b), nil
 		}).Once()
 
-	c := &Client{
-		ipv4conn: mockIPv4,
-		ipv6conn: nil,
-		ifaces:   []net.Interface{{Index: 1, Name: "eth0"}},
-	}
+	ifaces := []net.Interface{{Index: 1, Name: "eth0"}}
+	c := testClient(mockIPv4, nil, ifaces)
 
 	params := newLookupParams("myservice", "_http._tcp", "local", false,
 		make(chan *ServiceEntry), make(chan *ServiceEntry))
@@ -294,11 +424,8 @@ func TestClient_Query_Browse(t *testing.T) {
 			return len(b), nil
 		}).Once()
 
-	c := &Client{
-		ipv4conn: mockIPv4,
-		ipv6conn: nil,
-		ifaces:   []net.Interface{{Index: 1, Name: "eth0"}},
-	}
+	ifaces := []net.Interface{{Index: 1, Name: "eth0"}}
+	c := testClient(mockIPv4, nil, ifaces)
 
 	// No instance = browse mode
 	params := newLookupParams("", "_http._tcp", "local", true,

--- a/conn_ipv4.go
+++ b/conn_ipv4.go
@@ -1,9 +1,10 @@
 package zeroconf
 
 import (
-	"log"
+	"fmt"
 	"net"
 	"runtime"
+	"syscall"
 
 	"github.com/enbility/zeroconf/v3/api"
 	"golang.org/x/net/ipv4"
@@ -37,20 +38,32 @@ func (c *ipv4PacketConn) WriteTo(b []byte, ifIndex int, dst net.Addr) (n int, er
 	// On Windows, the ControlMessage for WriteTo is not implemented.
 	// Use SetMulticastInterface as fallback.
 	var cm *ipv4.ControlMessage
+
 	if ifIndex != 0 {
 		switch runtime.GOOS {
 		case "darwin", "ios", "linux":
 			cm = &ipv4.ControlMessage{IfIndex: ifIndex}
+
 		default:
-			// Windows and other platforms: use SetMulticastInterface
-			iface, _ := net.InterfaceByIndex(ifIndex)
-			if iface != nil {
-				if err := c.conn.SetMulticastInterface(iface); err != nil {
-					log.Printf("[WARN] mdns: Failed to set multicast interface: %v", err)
-				}
+			// Windows and other platforms: validate and set interface.
+			// CRITICAL: Return errors instead of logging them. The caller
+			// (via InterfaceManager.MarkFailed) handles removal and backoff.
+			iface, err := net.InterfaceByIndex(ifIndex)
+			if err != nil {
+				// Interface gone - wrap with ENXIO so isInterfaceGone() detects it
+				return 0, fmt.Errorf("interface index %d: %w", ifIndex, syscall.ENXIO)
+			}
+			// Verify interface is actually up
+			if iface.Flags&net.FlagUp == 0 {
+				return 0, fmt.Errorf("interface %s is down: %w", iface.Name, syscall.ENETDOWN)
+			}
+			if err := c.conn.SetMulticastInterface(iface); err != nil {
+				// Return the actual error - may contain WSAENETDOWN or similar
+				return 0, fmt.Errorf("set multicast interface %s: %w", iface.Name, err)
 			}
 		}
 	}
+
 	return c.conn.WriteTo(b, cm, dst)
 }
 

--- a/conn_ipv6.go
+++ b/conn_ipv6.go
@@ -1,9 +1,10 @@
 package zeroconf
 
 import (
-	"log"
+	"fmt"
 	"net"
 	"runtime"
+	"syscall"
 
 	"github.com/enbility/zeroconf/v3/api"
 	"golang.org/x/net/ipv6"
@@ -37,20 +38,32 @@ func (c *ipv6PacketConn) WriteTo(b []byte, ifIndex int, dst net.Addr) (n int, er
 	// On Windows, the ControlMessage for WriteTo is not implemented.
 	// Use SetMulticastInterface as fallback.
 	var cm *ipv6.ControlMessage
+
 	if ifIndex != 0 {
 		switch runtime.GOOS {
 		case "darwin", "ios", "linux":
 			cm = &ipv6.ControlMessage{IfIndex: ifIndex}
+
 		default:
-			// Windows and other platforms: use SetMulticastInterface
-			iface, _ := net.InterfaceByIndex(ifIndex)
-			if iface != nil {
-				if err := c.conn.SetMulticastInterface(iface); err != nil {
-					log.Printf("[WARN] mdns: Failed to set multicast interface: %v", err)
-				}
+			// Windows and other platforms: validate and set interface.
+			// CRITICAL: Return errors instead of logging them. The caller
+			// (via InterfaceManager.MarkFailed) handles removal and backoff.
+			iface, err := net.InterfaceByIndex(ifIndex)
+			if err != nil {
+				// Interface gone - wrap with ENXIO so isInterfaceGone() detects it
+				return 0, fmt.Errorf("interface index %d: %w", ifIndex, syscall.ENXIO)
+			}
+			// Verify interface is actually up
+			if iface.Flags&net.FlagUp == 0 {
+				return 0, fmt.Errorf("interface %s is down: %w", iface.Name, syscall.ENETDOWN)
+			}
+			if err := c.conn.SetMulticastInterface(iface); err != nil {
+				// Return the actual error - may contain WSAENETDOWN or similar
+				return 0, fmt.Errorf("set multicast interface %s: %w", iface.Name, err)
 			}
 		}
 	}
+
 	return c.conn.WriteTo(b, cm, dst)
 }
 

--- a/error_classify.go
+++ b/error_classify.go
@@ -1,0 +1,60 @@
+package zeroconf
+
+import (
+	"errors"
+	"strings"
+	"syscall"
+)
+
+// Windows socket error codes (not in standard syscall package).
+// These constants are safe to define cross-platform because errors.Is()
+// performs type comparison - on non-Windows systems, these simply won't match.
+const (
+	WSAENETDOWN      syscall.Errno = 10050 // Network is down
+	WSAEADDRNOTAVAIL syscall.Errno = 10049 // Cannot assign requested address
+	WSAEINVAL        syscall.Errno = 10022 // Invalid argument
+)
+
+// interfaceGoneErrors lists all error codes that indicate an interface is gone.
+var interfaceGoneErrors = []syscall.Errno{
+	// Unix errors
+	syscall.ENXIO,         // "no such device or address"
+	syscall.ENODEV,        // "no such device"
+	syscall.EADDRNOTAVAIL, // "can't assign requested address"
+	syscall.EINVAL,        // "invalid argument" (stale ifIndex)
+	syscall.ENETDOWN,      // "network is down"
+	syscall.ENETUNREACH,   // "network unreachable"
+	// Windows errors
+	WSAENETDOWN,
+	WSAEADDRNOTAVAIL,
+	WSAEINVAL,
+}
+
+// isInterfaceGone returns true if the error indicates the interface
+// is no longer available and should be removed from active set.
+//
+// Uses errors.Is() for proper unwrapping of fmt.Errorf("%w") chains.
+func isInterfaceGone(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Check known error codes
+	for _, e := range interfaceGoneErrors {
+		if errors.Is(err, e) {
+			return true
+		}
+	}
+
+	// Fallback: check error message patterns for unknown error codes.
+	// This handles edge cases on unusual platforms or new OS versions.
+	errStr := strings.ToLower(err.Error())
+	if strings.Contains(errStr, "no such device") ||
+		strings.Contains(errStr, "no such interface") ||
+		strings.Contains(errStr, "network is down") ||
+		strings.Contains(errStr, "network is unreachable") {
+		return true
+	}
+
+	return false
+}

--- a/error_classify_test.go
+++ b/error_classify_test.go
@@ -1,0 +1,131 @@
+package zeroconf
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+	"testing"
+)
+
+func TestIsInterfaceGone_Nil_ReturnsFalse(t *testing.T) {
+	if isInterfaceGone(nil) {
+		t.Error("expected false for nil error")
+	}
+}
+
+func TestIsInterfaceGone_ENXIO_ReturnsTrue(t *testing.T) {
+	err := syscall.ENXIO
+	if !isInterfaceGone(err) {
+		t.Errorf("expected true for ENXIO, got false")
+	}
+}
+
+func TestIsInterfaceGone_ENODEV_ReturnsTrue(t *testing.T) {
+	err := syscall.ENODEV
+	if !isInterfaceGone(err) {
+		t.Errorf("expected true for ENODEV, got false")
+	}
+}
+
+func TestIsInterfaceGone_EADDRNOTAVAIL_ReturnsTrue(t *testing.T) {
+	err := syscall.EADDRNOTAVAIL
+	if !isInterfaceGone(err) {
+		t.Errorf("expected true for EADDRNOTAVAIL, got false")
+	}
+}
+
+func TestIsInterfaceGone_EINVAL_ReturnsTrue(t *testing.T) {
+	err := syscall.EINVAL
+	if !isInterfaceGone(err) {
+		t.Errorf("expected true for EINVAL, got false")
+	}
+}
+
+func TestIsInterfaceGone_ENETDOWN_ReturnsTrue(t *testing.T) {
+	err := syscall.ENETDOWN
+	if !isInterfaceGone(err) {
+		t.Errorf("expected true for ENETDOWN, got false")
+	}
+}
+
+func TestIsInterfaceGone_ENETUNREACH_ReturnsTrue(t *testing.T) {
+	err := syscall.ENETUNREACH
+	if !isInterfaceGone(err) {
+		t.Errorf("expected true for ENETUNREACH, got false")
+	}
+}
+
+func TestIsInterfaceGone_WrappedError_ReturnsTrue(t *testing.T) {
+	// errors.Is() should unwrap fmt.Errorf("%w") chains
+	wrapped := fmt.Errorf("send failed: %w", syscall.ENXIO)
+	if !isInterfaceGone(wrapped) {
+		t.Errorf("expected true for wrapped ENXIO, got false")
+	}
+}
+
+func TestIsInterfaceGone_DoubleWrappedError_ReturnsTrue(t *testing.T) {
+	inner := fmt.Errorf("inner: %w", syscall.ENETDOWN)
+	outer := fmt.Errorf("outer: %w", inner)
+	if !isInterfaceGone(outer) {
+		t.Errorf("expected true for double-wrapped ENETDOWN, got false")
+	}
+}
+
+func TestIsInterfaceGone_TransientError_ReturnsFalse(t *testing.T) {
+	// EAGAIN is a transient error - should not remove interface
+	err := syscall.EAGAIN
+	if isInterfaceGone(err) {
+		t.Errorf("expected false for EAGAIN (transient), got true")
+	}
+}
+
+func TestIsInterfaceGone_ETIMEDOUT_ReturnsFalse(t *testing.T) {
+	// Timeout is transient - interface might still be fine
+	err := syscall.ETIMEDOUT
+	if isInterfaceGone(err) {
+		t.Errorf("expected false for ETIMEDOUT (transient), got true")
+	}
+}
+
+func TestIsInterfaceGone_GenericError_ReturnsFalse(t *testing.T) {
+	err := errors.New("some random error")
+	if isInterfaceGone(err) {
+		t.Errorf("expected false for generic error, got true")
+	}
+}
+
+func TestIsInterfaceGone_FallbackMessageParsing_NoSuchDevice(t *testing.T) {
+	// Fallback for unknown error codes with recognizable message
+	err := errors.New("operation failed: no such device")
+	if !isInterfaceGone(err) {
+		t.Errorf("expected true for 'no such device' message, got false")
+	}
+}
+
+func TestIsInterfaceGone_FallbackMessageParsing_NetworkDown(t *testing.T) {
+	err := errors.New("send error: network is down")
+	if !isInterfaceGone(err) {
+		t.Errorf("expected true for 'network is down' message, got false")
+	}
+}
+
+func TestIsInterfaceGone_FallbackMessageParsing_NetworkUnreachable(t *testing.T) {
+	err := errors.New("cannot route: network is unreachable")
+	if !isInterfaceGone(err) {
+		t.Errorf("expected true for 'network is unreachable' message, got false")
+	}
+}
+
+func TestIsInterfaceGone_FallbackMessageParsing_NoSuchInterface(t *testing.T) {
+	err := errors.New("interface eth0: no such interface")
+	if !isInterfaceGone(err) {
+		t.Errorf("expected true for 'no such interface' message, got false")
+	}
+}
+
+func TestIsInterfaceGone_FallbackMessageParsing_CaseInsensitive(t *testing.T) {
+	err := errors.New("NETWORK IS DOWN")
+	if !isInterfaceGone(err) {
+		t.Errorf("expected true for uppercase 'NETWORK IS DOWN', got false")
+	}
+}

--- a/interface_manager.go
+++ b/interface_manager.go
@@ -1,0 +1,251 @@
+package zeroconf
+
+import (
+	"net"
+	"sync"
+	"time"
+)
+
+// Backoff intervals for adaptive retry strategy.
+// Fast first retry for user-initiated reconnects, then progressive delay.
+const (
+	backoffFirst  = 1 * time.Second  // First retry: fast for quick reconnects
+	backoffSecond = 5 * time.Second  // Second retry: moderate delay
+	backoffMax    = 30 * time.Second // Subsequent retries: avoid thrashing
+)
+
+// failureState tracks failure history for adaptive backoff.
+type failureState struct {
+	count   int       // Number of consecutive failures
+	retryAt time.Time // Don't retry until this time
+}
+
+// InterfaceManager tracks active and failed interfaces for one IP version.
+// Thread-safe. Create separate instances for IPv4 and IPv6.
+//
+// Concurrency model:
+//   - ActiveIndices() returns a snapshot; iteration is lock-free
+//   - MarkFailed() is idempotent; safe to call even if already removed
+//   - Sync() runs periodically in background; updates are atomic
+type InterfaceManager struct {
+	mu        sync.RWMutex
+	active    map[int]string           // ifIndex -> name (currently usable)
+	failures  map[string]*failureState // name -> failure tracking (adaptive backoff)
+	requested []string                 // Mode selector:
+	//   nil     = dynamic mode (accept any multicast interface)
+	//   non-nil = explicit mode (only names in this slice)
+	// NOTE: Empty slice []string{} is treated as explicit mode
+	// with NO allowed interfaces - almost certainly a bug.
+	// Callers should pass nil for dynamic mode, not empty slice.
+}
+
+// NewInterfaceManager creates a manager with initial interfaces.
+// If requested is nil, dynamic mode is used (accepts new interfaces).
+// If requested is non-nil, only those interface names are ever used.
+func NewInterfaceManager(initial []net.Interface, requested []string) *InterfaceManager {
+	m := &InterfaceManager{
+		active:    make(map[int]string, len(initial)),
+		failures:  make(map[string]*failureState),
+		requested: requested,
+	}
+	for _, iface := range initial {
+		m.active[iface.Index] = iface.Name
+	}
+	return m
+}
+
+// ActiveIndices returns current active interface indices.
+// Call this in send loops - never cache the result.
+//
+// The returned slice is a snapshot. The caller iterates over it while
+// the sync goroutine may modify the active map. This is safe because:
+//   - Sends to removed indices fail fast and call MarkFailed (idempotent)
+//   - New indices are picked up on the next ActiveIndices() call
+func (m *InterfaceManager) ActiveIndices() []int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	result := make([]int, 0, len(m.active))
+	for idx := range m.active {
+		result = append(result, idx)
+	}
+	return result
+}
+
+// MarkFailed removes an interface from active set if error indicates it's gone.
+// Uses adaptive backoff: first failure = 1s, second = 5s, third+ = 30s.
+//
+// This method is IDEMPOTENT: safe to call even if the interface was already
+// removed by a concurrent Sync() call.
+//
+// Returns true if the error indicated the interface is gone.
+func (m *InterfaceManager) MarkFailed(ifIndex int, err error) bool {
+	if !isInterfaceGone(err) {
+		return false // Transient error, don't remove
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Get name from active map (if still present)
+	name := m.active[ifIndex]
+	if name == "" {
+		// Already removed - this is the benign race case
+		// We can't set backoff without knowing the name, but that's OK:
+		// either Sync() already set it, or we don't have enough info.
+		return true
+	}
+
+	// Remove from active (idempotent - no-op if not present)
+	delete(m.active, ifIndex)
+
+	// Update failure tracking with adaptive backoff
+	m.recordFailure(name)
+
+	return true
+}
+
+// recordFailure updates the failure state for an interface (must hold lock).
+func (m *InterfaceManager) recordFailure(name string) {
+	state := m.failures[name]
+	if state == nil {
+		state = &failureState{}
+		m.failures[name] = state
+	}
+	state.count++
+
+	// Adaptive backoff based on failure count
+	var backoff time.Duration
+	switch state.count {
+	case 1:
+		backoff = backoffFirst // 1s - fast retry for quick reconnects
+	case 2:
+		backoff = backoffSecond // 5s - moderate delay
+	default:
+		backoff = backoffMax // 30s - avoid thrashing
+	}
+	state.retryAt = time.Now().Add(backoff)
+}
+
+// Sync updates state based on currently available interfaces.
+// Returns interfaces that were recovered and need JoinGroup calls.
+//
+// Handles:
+//   - Disappeared interfaces (removes from active, sets backoff)
+//   - Index changes (interface reconnects with different index)
+//   - New interfaces in dynamic mode
+//   - Recovery after backoff expires
+func (m *InterfaceManager) Sync(current []net.Interface) []net.Interface {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := time.Now()
+	currentByName := make(map[string]net.Interface, len(current))
+	for _, iface := range current {
+		currentByName[iface.Name] = iface
+	}
+
+	// Step 1: Remove disappeared interfaces
+	for idx, name := range m.active {
+		if _, exists := currentByName[name]; !exists {
+			delete(m.active, idx)
+			m.recordFailure(name)
+		}
+	}
+
+	// Step 2: Find interfaces to recover and clean up stale indices
+	var recovered []net.Interface
+	for _, iface := range current {
+		if m.shouldRecover(iface, now) {
+			// Clean up stale index before adding to recovered list
+			m.cleanupStaleIndex(iface)
+			recovered = append(recovered, iface)
+		}
+	}
+
+	return recovered
+}
+
+// shouldRecover checks if an interface should be recovered (must hold lock).
+// NOTE: This is a pure predicate - it does NOT mutate state.
+// Use cleanupStaleIndex() separately to handle index changes.
+func (m *InterfaceManager) shouldRecover(iface net.Interface, now time.Time) bool {
+	// Check if already active with same index
+	if existingName, ok := m.active[iface.Index]; ok && existingName == iface.Name {
+		return false // Already active, nothing to do
+	}
+
+	// Check mode restrictions
+	if !m.isAllowed(iface.Name) {
+		return false
+	}
+
+	// Check backoff
+	if state := m.failures[iface.Name]; state != nil && now.Before(state.retryAt) {
+		return false
+	}
+
+	return true
+}
+
+// isAllowed checks if interface name is allowed by mode (must hold lock).
+func (m *InterfaceManager) isAllowed(name string) bool {
+	if m.requested == nil {
+		return true // Dynamic mode: allow all
+	}
+	for _, allowed := range m.requested {
+		if allowed == name {
+			return true
+		}
+	}
+	return false // Explicit mode: not in requested set
+}
+
+// cleanupStaleIndex removes old index mapping if interface reconnected with new index.
+// Must hold lock. Call this before adding new mapping for recovered interfaces.
+func (m *InterfaceManager) cleanupStaleIndex(iface net.Interface) {
+	for idx, name := range m.active {
+		if name == iface.Name && idx != iface.Index {
+			delete(m.active, idx)
+			return // Only one stale mapping possible per name
+		}
+	}
+}
+
+// Activate adds an interface to the active set.
+// Called after successful JoinGroup. Clears failure history.
+// Handles the case where interface reconnected with a different index.
+func (m *InterfaceManager) Activate(iface net.Interface) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Remove stale index mapping if interface reconnected with new index
+	m.cleanupStaleIndex(iface)
+
+	m.active[iface.Index] = iface.Name
+	delete(m.failures, iface.Name) // Clear failure history on success
+}
+
+// SetBackoff marks an interface as temporarily failed (e.g., JoinGroup failed).
+// Increments the failure counter for adaptive backoff.
+func (m *InterfaceManager) SetBackoff(ifName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.recordFailure(ifName)
+}
+
+// GetActiveInterfaces returns full interface objects for all active indices.
+// Used for IP address collection (avoids race between ActiveIndices and lookup).
+func (m *InterfaceManager) GetActiveInterfaces() []net.Interface {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	result := make([]net.Interface, 0, len(m.active))
+	for idx := range m.active {
+		if iface, err := net.InterfaceByIndex(idx); err == nil {
+			result = append(result, *iface)
+		}
+	}
+	return result
+}

--- a/interface_manager_test.go
+++ b/interface_manager_test.go
@@ -1,0 +1,576 @@
+package zeroconf
+
+import (
+	"net"
+	"sort"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// Helper to create mock interfaces
+func mockInterface(index int, name string) net.Interface {
+	return net.Interface{
+		Index: index,
+		Name:  name,
+		Flags: net.FlagUp | net.FlagMulticast,
+	}
+}
+
+func mockInterfaces(specs ...struct{ idx int; name string }) []net.Interface {
+	result := make([]net.Interface, len(specs))
+	for i, s := range specs {
+		result[i] = mockInterface(s.idx, s.name)
+	}
+	return result
+}
+
+// ============================================================================
+// NewInterfaceManager Tests
+// ============================================================================
+
+func TestInterfaceManager_NewDynamicMode(t *testing.T) {
+	ifaces := []net.Interface{mockInterface(1, "eth0"), mockInterface(2, "wlan0")}
+
+	// nil requested = dynamic mode
+	mgr := NewInterfaceManager(ifaces, nil)
+
+	indices := mgr.ActiveIndices()
+	if len(indices) != 2 {
+		t.Errorf("expected 2 active indices, got %d", len(indices))
+	}
+}
+
+func TestInterfaceManager_NewExplicitMode(t *testing.T) {
+	ifaces := []net.Interface{mockInterface(1, "eth0"), mockInterface(2, "wlan0")}
+	requested := []string{"eth0", "wlan0"}
+
+	mgr := NewInterfaceManager(ifaces, requested)
+
+	indices := mgr.ActiveIndices()
+	if len(indices) != 2 {
+		t.Errorf("expected 2 active indices, got %d", len(indices))
+	}
+}
+
+func TestInterfaceManager_NewEmptyInitial(t *testing.T) {
+	mgr := NewInterfaceManager(nil, nil)
+
+	indices := mgr.ActiveIndices()
+	if len(indices) != 0 {
+		t.Errorf("expected 0 active indices, got %d", len(indices))
+	}
+}
+
+// ============================================================================
+// ActiveIndices Tests
+// ============================================================================
+
+func TestInterfaceManager_ActiveIndices_ReturnsSnapshot(t *testing.T) {
+	ifaces := []net.Interface{mockInterface(1, "eth0"), mockInterface(5, "wlan0")}
+	mgr := NewInterfaceManager(ifaces, nil)
+
+	indices := mgr.ActiveIndices()
+
+	// Should contain both indices
+	sort.Ints(indices)
+	if len(indices) != 2 || indices[0] != 1 || indices[1] != 5 {
+		t.Errorf("expected [1, 5], got %v", indices)
+	}
+}
+
+func TestInterfaceManager_ActiveIndices_ReturnsEmptySliceNotNil(t *testing.T) {
+	mgr := NewInterfaceManager(nil, nil)
+
+	indices := mgr.ActiveIndices()
+
+	if indices == nil {
+		t.Error("expected empty slice, got nil")
+	}
+	if len(indices) != 0 {
+		t.Errorf("expected length 0, got %d", len(indices))
+	}
+}
+
+// ============================================================================
+// MarkFailed Tests
+// ============================================================================
+
+func TestInterfaceManager_MarkFailed_InterfaceGoneError_RemovesInterface(t *testing.T) {
+	ifaces := []net.Interface{mockInterface(1, "eth0"), mockInterface(2, "wlan0")}
+	mgr := NewInterfaceManager(ifaces, nil)
+
+	// ENXIO indicates interface is gone
+	removed := mgr.MarkFailed(1, syscall.ENXIO)
+
+	if !removed {
+		t.Error("expected MarkFailed to return true for ENXIO")
+	}
+
+	indices := mgr.ActiveIndices()
+	if len(indices) != 1 {
+		t.Errorf("expected 1 active index after removal, got %d", len(indices))
+	}
+	if indices[0] != 2 {
+		t.Errorf("expected remaining index to be 2, got %d", indices[0])
+	}
+}
+
+func TestInterfaceManager_MarkFailed_TransientError_KeepsInterface(t *testing.T) {
+	ifaces := []net.Interface{mockInterface(1, "eth0")}
+	mgr := NewInterfaceManager(ifaces, nil)
+
+	// EAGAIN is transient - should not remove
+	removed := mgr.MarkFailed(1, syscall.EAGAIN)
+
+	if removed {
+		t.Error("expected MarkFailed to return false for transient error")
+	}
+
+	indices := mgr.ActiveIndices()
+	if len(indices) != 1 {
+		t.Errorf("expected interface to remain active, got %d active", len(indices))
+	}
+}
+
+func TestInterfaceManager_MarkFailed_Idempotent_SafeWhenAlreadyRemoved(t *testing.T) {
+	ifaces := []net.Interface{mockInterface(1, "eth0")}
+	mgr := NewInterfaceManager(ifaces, nil)
+
+	// First removal
+	mgr.MarkFailed(1, syscall.ENXIO)
+
+	// Second removal of same index - should not panic
+	removed := mgr.MarkFailed(1, syscall.ENXIO)
+
+	// Returns true because error still indicates "interface gone"
+	if !removed {
+		t.Error("expected MarkFailed to return true even when already removed")
+	}
+
+	indices := mgr.ActiveIndices()
+	if len(indices) != 0 {
+		t.Errorf("expected 0 active indices, got %d", len(indices))
+	}
+}
+
+func TestInterfaceManager_MarkFailed_UnknownIndex_DoesNotPanic(t *testing.T) {
+	mgr := NewInterfaceManager(nil, nil)
+
+	// Index 999 was never added - should not panic
+	removed := mgr.MarkFailed(999, syscall.ENXIO)
+
+	if !removed {
+		t.Error("expected true because error indicates interface gone")
+	}
+}
+
+// ============================================================================
+// Adaptive Backoff Tests
+// ============================================================================
+
+func TestInterfaceManager_AdaptiveBackoff_FirstFailure1s(t *testing.T) {
+	ifaces := []net.Interface{mockInterface(1, "eth0")}
+	mgr := NewInterfaceManager(ifaces, nil)
+
+	// Fail the interface
+	mgr.MarkFailed(1, syscall.ENXIO)
+
+	// Check backoff is ~1s
+	mgr.mu.RLock()
+	state := mgr.failures["eth0"]
+	mgr.mu.RUnlock()
+
+	if state == nil {
+		t.Fatal("expected failure state to exist")
+	}
+	if state.count != 1 {
+		t.Errorf("expected count 1, got %d", state.count)
+	}
+
+	// retryAt should be ~1s from now
+	expectedBackoff := backoffFirst
+	actualBackoff := time.Until(state.retryAt)
+	if actualBackoff < expectedBackoff-100*time.Millisecond || actualBackoff > expectedBackoff+100*time.Millisecond {
+		t.Errorf("expected backoff ~%v, got %v", expectedBackoff, actualBackoff)
+	}
+}
+
+func TestInterfaceManager_AdaptiveBackoff_SecondFailure5s(t *testing.T) {
+	ifaces := []net.Interface{mockInterface(1, "eth0")}
+	mgr := NewInterfaceManager(ifaces, nil)
+
+	// First failure
+	mgr.MarkFailed(1, syscall.ENXIO)
+
+	// Manually re-add and fail again (simulating Sync + re-fail)
+	mgr.mu.Lock()
+	mgr.active[1] = "eth0"
+	mgr.mu.Unlock()
+	mgr.MarkFailed(1, syscall.ENXIO)
+
+	mgr.mu.RLock()
+	state := mgr.failures["eth0"]
+	mgr.mu.RUnlock()
+
+	if state.count != 2 {
+		t.Errorf("expected count 2, got %d", state.count)
+	}
+
+	expectedBackoff := backoffSecond
+	actualBackoff := time.Until(state.retryAt)
+	if actualBackoff < expectedBackoff-100*time.Millisecond || actualBackoff > expectedBackoff+100*time.Millisecond {
+		t.Errorf("expected backoff ~%v, got %v", expectedBackoff, actualBackoff)
+	}
+}
+
+func TestInterfaceManager_AdaptiveBackoff_ThirdFailure30s(t *testing.T) {
+	ifaces := []net.Interface{mockInterface(1, "eth0")}
+	mgr := NewInterfaceManager(ifaces, nil)
+
+	// Three failures
+	for i := 0; i < 3; i++ {
+		mgr.mu.Lock()
+		mgr.active[1] = "eth0"
+		mgr.mu.Unlock()
+		mgr.MarkFailed(1, syscall.ENXIO)
+	}
+
+	mgr.mu.RLock()
+	state := mgr.failures["eth0"]
+	mgr.mu.RUnlock()
+
+	if state.count != 3 {
+		t.Errorf("expected count 3, got %d", state.count)
+	}
+
+	expectedBackoff := backoffMax
+	actualBackoff := time.Until(state.retryAt)
+	if actualBackoff < expectedBackoff-100*time.Millisecond || actualBackoff > expectedBackoff+100*time.Millisecond {
+		t.Errorf("expected backoff ~%v, got %v", expectedBackoff, actualBackoff)
+	}
+}
+
+// ============================================================================
+// Sync Tests
+// ============================================================================
+
+func TestInterfaceManager_Sync_DetectsDisappeared(t *testing.T) {
+	ifaces := []net.Interface{mockInterface(1, "eth0"), mockInterface(2, "wlan0")}
+	mgr := NewInterfaceManager(ifaces, nil)
+
+	// wlan0 disappeared
+	current := []net.Interface{mockInterface(1, "eth0")}
+
+	recovered := mgr.Sync(current)
+
+	// Nothing to recover (eth0 was already active)
+	if len(recovered) != 0 {
+		t.Errorf("expected 0 recovered, got %d", len(recovered))
+	}
+
+	// wlan0 should be removed
+	indices := mgr.ActiveIndices()
+	if len(indices) != 1 || indices[0] != 1 {
+		t.Errorf("expected [1], got %v", indices)
+	}
+
+	// wlan0 should have failure state
+	mgr.mu.RLock()
+	_, hasFailure := mgr.failures["wlan0"]
+	mgr.mu.RUnlock()
+	if !hasFailure {
+		t.Error("expected failure state for wlan0")
+	}
+}
+
+func TestInterfaceManager_Sync_RecoversAfterBackoff(t *testing.T) {
+	ifaces := []net.Interface{mockInterface(1, "eth0")}
+	mgr := NewInterfaceManager(ifaces, nil)
+
+	// Remove eth0 and set backoff in the past
+	mgr.mu.Lock()
+	delete(mgr.active, 1)
+	mgr.failures["eth0"] = &failureState{
+		count:   1,
+		retryAt: time.Now().Add(-1 * time.Second), // Backoff expired
+	}
+	mgr.mu.Unlock()
+
+	// eth0 reappears
+	current := []net.Interface{mockInterface(1, "eth0")}
+
+	recovered := mgr.Sync(current)
+
+	if len(recovered) != 1 {
+		t.Fatalf("expected 1 recovered, got %d", len(recovered))
+	}
+	if recovered[0].Name != "eth0" {
+		t.Errorf("expected eth0 to be recovered, got %s", recovered[0].Name)
+	}
+}
+
+func TestInterfaceManager_Sync_RespectsBackoffNotExpired(t *testing.T) {
+	ifaces := []net.Interface{mockInterface(1, "eth0")}
+	mgr := NewInterfaceManager(ifaces, nil)
+
+	// Remove eth0 and set backoff in the future
+	mgr.mu.Lock()
+	delete(mgr.active, 1)
+	mgr.failures["eth0"] = &failureState{
+		count:   1,
+		retryAt: time.Now().Add(10 * time.Second), // Backoff NOT expired
+	}
+	mgr.mu.Unlock()
+
+	current := []net.Interface{mockInterface(1, "eth0")}
+
+	recovered := mgr.Sync(current)
+
+	// Should NOT recover yet
+	if len(recovered) != 0 {
+		t.Errorf("expected 0 recovered (backoff not expired), got %d", len(recovered))
+	}
+}
+
+func TestInterfaceManager_Sync_RespectsExplicitMode(t *testing.T) {
+	ifaces := []net.Interface{mockInterface(1, "eth0")}
+	requested := []string{"eth0"} // Only eth0 allowed
+	mgr := NewInterfaceManager(ifaces, requested)
+
+	// New interface wlan0 appears (not in requested list)
+	current := []net.Interface{mockInterface(1, "eth0"), mockInterface(2, "wlan0")}
+
+	recovered := mgr.Sync(current)
+
+	// wlan0 should NOT be recovered (not in requested)
+	for _, iface := range recovered {
+		if iface.Name == "wlan0" {
+			t.Error("wlan0 should not be recovered in explicit mode")
+		}
+	}
+
+	// Only eth0 should be active
+	indices := mgr.ActiveIndices()
+	if len(indices) != 1 || indices[0] != 1 {
+		t.Errorf("expected [1], got %v", indices)
+	}
+}
+
+func TestInterfaceManager_Sync_AcceptsNewInDynamicMode(t *testing.T) {
+	ifaces := []net.Interface{mockInterface(1, "eth0")}
+	mgr := NewInterfaceManager(ifaces, nil) // nil = dynamic mode
+
+	// New interface wlan0 appears
+	current := []net.Interface{mockInterface(1, "eth0"), mockInterface(2, "wlan0")}
+
+	recovered := mgr.Sync(current)
+
+	// wlan0 should be in recovered list
+	found := false
+	for _, iface := range recovered {
+		if iface.Name == "wlan0" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected wlan0 to be in recovered list (dynamic mode)")
+	}
+}
+
+func TestInterfaceManager_Sync_DetectsIndexChange(t *testing.T) {
+	// eth0 starts with index 1
+	ifaces := []net.Interface{mockInterface(1, "eth0")}
+	mgr := NewInterfaceManager(ifaces, nil)
+
+	// eth0 reconnects with index 5 (different index, same name)
+	current := []net.Interface{mockInterface(5, "eth0")}
+
+	recovered := mgr.Sync(current)
+
+	// eth0 should be recovered with new index
+	if len(recovered) != 1 {
+		t.Fatalf("expected 1 recovered, got %d", len(recovered))
+	}
+	if recovered[0].Index != 5 || recovered[0].Name != "eth0" {
+		t.Errorf("expected {5, eth0}, got {%d, %s}", recovered[0].Index, recovered[0].Name)
+	}
+
+	// Old index 1 should be removed
+	mgr.mu.RLock()
+	_, hasOld := mgr.active[1]
+	mgr.mu.RUnlock()
+	if hasOld {
+		t.Error("old index 1 should be removed")
+	}
+}
+
+// ============================================================================
+// Activate Tests
+// ============================================================================
+
+func TestInterfaceManager_Activate_AddsToActive(t *testing.T) {
+	mgr := NewInterfaceManager(nil, nil)
+
+	iface := mockInterface(3, "eth1")
+	mgr.Activate(iface)
+
+	indices := mgr.ActiveIndices()
+	if len(indices) != 1 || indices[0] != 3 {
+		t.Errorf("expected [3], got %v", indices)
+	}
+}
+
+func TestInterfaceManager_Activate_ClearsFailureHistory(t *testing.T) {
+	mgr := NewInterfaceManager(nil, nil)
+
+	// Set up failure state
+	mgr.mu.Lock()
+	mgr.failures["eth1"] = &failureState{count: 5, retryAt: time.Now().Add(time.Hour)}
+	mgr.mu.Unlock()
+
+	// Activate should clear it
+	iface := mockInterface(3, "eth1")
+	mgr.Activate(iface)
+
+	mgr.mu.RLock()
+	_, hasFailure := mgr.failures["eth1"]
+	mgr.mu.RUnlock()
+
+	if hasFailure {
+		t.Error("expected failure history to be cleared after Activate")
+	}
+}
+
+func TestInterfaceManager_Activate_HandlesIndexChange(t *testing.T) {
+	// Start with eth0 at index 1
+	ifaces := []net.Interface{mockInterface(1, "eth0")}
+	mgr := NewInterfaceManager(ifaces, nil)
+
+	// Activate eth0 with new index 5
+	mgr.Activate(mockInterface(5, "eth0"))
+
+	indices := mgr.ActiveIndices()
+	sort.Ints(indices)
+
+	// Should only have index 5, not both 1 and 5
+	if len(indices) != 1 || indices[0] != 5 {
+		t.Errorf("expected [5], got %v", indices)
+	}
+}
+
+// ============================================================================
+// SetBackoff Tests
+// ============================================================================
+
+func TestInterfaceManager_SetBackoff_SetsFailureState(t *testing.T) {
+	mgr := NewInterfaceManager(nil, nil)
+
+	mgr.SetBackoff("eth0")
+
+	mgr.mu.RLock()
+	state := mgr.failures["eth0"]
+	mgr.mu.RUnlock()
+
+	if state == nil {
+		t.Fatal("expected failure state to be set")
+	}
+	if state.count != 1 {
+		t.Errorf("expected count 1, got %d", state.count)
+	}
+}
+
+// ============================================================================
+// GetActiveInterfaces Tests
+// ============================================================================
+
+func TestInterfaceManager_GetActiveInterfaces_ReturnsInterfaces(t *testing.T) {
+	// This test requires actual system interfaces, so we'll just test the empty case
+	mgr := NewInterfaceManager(nil, nil)
+
+	ifaces := mgr.GetActiveInterfaces()
+
+	if ifaces == nil {
+		t.Error("expected empty slice, got nil")
+	}
+	if len(ifaces) != 0 {
+		t.Errorf("expected 0 interfaces, got %d", len(ifaces))
+	}
+}
+
+// ============================================================================
+// Concurrency Tests
+// ============================================================================
+
+func TestInterfaceManager_Concurrent_ReadWrite(t *testing.T) {
+	ifaces := []net.Interface{mockInterface(1, "eth0"), mockInterface(2, "wlan0")}
+	mgr := NewInterfaceManager(ifaces, nil)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Reader goroutine
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = mgr.ActiveIndices()
+			}
+		}
+	}()
+
+	// Writer goroutine - MarkFailed
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+				mgr.MarkFailed(1, syscall.ENXIO)
+			}
+		}
+	}()
+
+	// Writer goroutine - Sync
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+				mgr.Sync(ifaces)
+			}
+		}
+	}()
+
+	// Writer goroutine - Activate
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+				mgr.Activate(mockInterface(3, "eth1"))
+			}
+		}
+	}()
+
+	// Let them run for a bit
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+
+	// If we get here without deadlock or panic, the test passes
+}

--- a/server.go
+++ b/server.go
@@ -842,6 +842,21 @@ func (s *Server) runInterfaceSync() {
 // syncInterfaces updates both interface managers with current system state.
 func (s *Server) syncInterfaces() {
 	current := s.provider.MulticastInterfaces()
-	s.ipv4Mgr.Sync(current)
-	s.ipv6Mgr.Sync(current)
+
+	// Helper to sync a single manager
+	syncManager := func(mgr *InterfaceManager, conn api.PacketConn, groupIP net.IP) {
+		if conn == nil || mgr == nil {
+			return
+		}
+		for _, iface := range mgr.Sync(current) {
+			if err := conn.JoinGroup(&iface, &net.UDPAddr{IP: groupIP}); err != nil {
+				mgr.SetBackoff(iface.Name)
+			} else {
+				mgr.Activate(iface)
+			}
+		}
+	}
+
+	syncManager(s.ipv4Mgr, s.ipv4conn, mdnsGroupIPv4)
+	syncManager(s.ipv6Mgr, s.ipv6conn, mdnsGroupIPv6)
 }

--- a/server.go
+++ b/server.go
@@ -24,6 +24,7 @@ var defaultTTL uint32 = 3200
 type serverOpts struct {
 	ttl         uint32
 	connFactory api.ConnectionFactory
+	provider    api.InterfaceProvider
 }
 
 func applyServerOpts(options ...ServerOption) serverOpts {
@@ -54,6 +55,14 @@ func TTL(ttl uint32) ServerOption {
 func WithServerConnFactory(factory api.ConnectionFactory) ServerOption {
 	return func(o *serverOpts) {
 		o.connFactory = factory
+	}
+}
+
+// WithServerInterfaceProvider sets a custom interface provider for the server.
+// This is primarily useful for testing with mock interface lists.
+func WithServerInterfaceProvider(provider api.InterfaceProvider) ServerOption {
+	return func(o *serverOpts) {
+		o.provider = provider
 	}
 }
 
@@ -179,7 +188,9 @@ type Server struct {
 	service  *ServiceEntry
 	ipv4conn api.PacketConn
 	ipv6conn api.PacketConn
-	ifaces   []net.Interface
+	ipv4Mgr  *InterfaceManager
+	ipv6Mgr  *InterfaceManager
+	provider api.InterfaceProvider
 
 	shouldShutdown chan struct{}
 	shutdownLock   sync.Mutex
@@ -190,10 +201,31 @@ type Server struct {
 
 // Constructs server structure
 func newServer(ifaces []net.Interface, opts serverOpts) (*Server, error) {
+	// Get interface provider (use default if not injected for testing)
+	provider := opts.provider
+	if provider == nil {
+		provider = NewInterfaceProvider()
+	}
+
 	factory := opts.connFactory
 	if factory == nil {
 		factory = NewConnectionFactory()
 	}
+
+	// Determine mode
+	var requested []string
+	if len(ifaces) > 0 {
+		requested = make([]string, len(ifaces))
+		for i, iface := range ifaces {
+			requested[i] = iface.Name
+		}
+	} else {
+		ifaces = provider.MulticastInterfaces()
+	}
+
+	// Create SEPARATE managers for IPv4 and IPv6.
+	ipv4Mgr := NewInterfaceManager(ifaces, requested)
+	ipv6Mgr := NewInterfaceManager(ifaces, requested)
 
 	ipv4conn, err4 := factory.CreateIPv4Conn(ifaces)
 	if err4 != nil {
@@ -211,7 +243,9 @@ func newServer(ifaces []net.Interface, opts serverOpts) (*Server, error) {
 	s := &Server{
 		ipv4conn:       ipv4conn,
 		ipv6conn:       ipv6conn,
-		ifaces:         ifaces,
+		ipv4Mgr:        ipv4Mgr,
+		ipv6Mgr:        ipv6Mgr,
+		provider:       provider,
 		ttl:            opts.ttl,
 		shouldShutdown: make(chan struct{}),
 	}
@@ -230,6 +264,10 @@ func (s *Server) start() {
 	}
 	s.refCount.Add(1)
 	go s.probe()
+
+	// Start interface sync goroutine
+	s.refCount.Add(1)
+	go s.runInterfaceSync()
 }
 
 // SetText updates and announces the TXT records
@@ -592,7 +630,12 @@ func (s *Server) probe() {
 	//    at least a factor of two with every response sent.
 	timeout := time.Second
 	for i := 0; i < multicastRepetitions; i++ {
-		for _, intf := range s.ifaces {
+		// Use active interfaces from both managers
+		activeIfaces := s.ipv4Mgr.GetActiveInterfaces()
+		if len(activeIfaces) == 0 {
+			activeIfaces = s.ipv6Mgr.GetActiveInterfaces()
+		}
+		for _, intf := range activeIfaces {
 			resp := new(dns.Msg)
 			resp.MsgHdr.Response = true
 			// TODO: make response authoritative if we are the publisher
@@ -735,27 +778,33 @@ func (s *Server) multicastResponse(msg *dns.Msg, ifIndex int) error {
 		return fmt.Errorf("failed to pack msg %v: %w", msg, err)
 	}
 
-	// Determine which interfaces to send to
-	var ifaces []int
-	if ifIndex != 0 {
-		ifaces = []int{ifIndex}
-	} else {
-		for _, intf := range s.ifaces {
-			ifaces = append(ifaces, intf.Index)
-		}
-	}
-
 	// Send to IPv4 multicast group
 	if s.ipv4conn != nil {
-		for _, idx := range ifaces {
-			_, _ = s.ipv4conn.WriteTo(buf, idx, ipv4Addr)
+		var indices []int
+		if ifIndex != 0 {
+			indices = []int{ifIndex}
+		} else {
+			indices = s.ipv4Mgr.ActiveIndices()
+		}
+		for _, idx := range indices {
+			if _, err := s.ipv4conn.WriteTo(buf, idx, ipv4Addr); err != nil {
+				s.ipv4Mgr.MarkFailed(idx, err)
+			}
 		}
 	}
 
 	// Send to IPv6 multicast group
 	if s.ipv6conn != nil {
-		for _, idx := range ifaces {
-			_, _ = s.ipv6conn.WriteTo(buf, idx, ipv6Addr)
+		var indices []int
+		if ifIndex != 0 {
+			indices = []int{ifIndex}
+		} else {
+			indices = s.ipv6Mgr.ActiveIndices()
+		}
+		for _, idx := range indices {
+			if _, err := s.ipv6conn.WriteTo(buf, idx, ipv6Addr); err != nil {
+				s.ipv6Mgr.MarkFailed(idx, err)
+			}
 		}
 	}
 
@@ -770,4 +819,29 @@ func isUnicastQuestion(q dns.Question) bool {
 	//    qclass field is used to indicate that unicast responses are preferred
 	//    for this particular question.  (See Section 5.4.)
 	return q.Qclass&qClassCacheFlush != 0
+}
+
+// runInterfaceSync periodically syncs the interface managers with the current
+// system interface state, detecting recovered interfaces.
+func (s *Server) runInterfaceSync() {
+	defer s.refCount.Done()
+
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-s.shouldShutdown:
+			return
+		case <-ticker.C:
+			s.syncInterfaces()
+		}
+	}
+}
+
+// syncInterfaces updates both interface managers with current system state.
+func (s *Server) syncInterfaces() {
+	current := s.provider.MulticastInterfaces()
+	s.ipv4Mgr.Sync(current)
+	s.ipv6Mgr.Sync(current)
 }

--- a/server.go
+++ b/server.go
@@ -631,10 +631,10 @@ func (s *Server) probe() {
 	timeout := time.Second
 	for i := 0; i < multicastRepetitions; i++ {
 		// Use active interfaces from both managers
-		activeIfaces := s.ipv4Mgr.GetActiveInterfaces()
-		if len(activeIfaces) == 0 {
-			activeIfaces = s.ipv6Mgr.GetActiveInterfaces()
-		}
+		ipv4ActiveIfaces := s.ipv4Mgr.GetActiveInterfaces()
+		ipv6ActiveIfaces := s.ipv6Mgr.GetActiveInterfaces()
+
+		activeIfaces := mergeInterfaces(ipv4ActiveIfaces, ipv6ActiveIfaces)
 		for _, intf := range activeIfaces {
 			resp := new(dns.Msg)
 			resp.MsgHdr.Response = true
@@ -859,4 +859,26 @@ func (s *Server) syncInterfaces() {
 
 	syncManager(s.ipv4Mgr, s.ipv4conn, mdnsGroupIPv4)
 	syncManager(s.ipv6Mgr, s.ipv6conn, mdnsGroupIPv6)
+}
+
+func mergeInterfaces(ipv4Ifaces, ipv6Ifaces []net.Interface) []net.Interface {
+	ifacesMap := make(map[string]net.Interface)
+	// add all IPv4 interfaces
+	for _, intf := range ipv4Ifaces {
+		ifacesMap[intf.Name] = intf
+	}
+
+	// check for IPv6 interfaces that are not supporting IPv4 and adding them
+	for _, intf := range ipv6Ifaces {
+		if _, exists := ifacesMap[intf.Name]; !exists {
+			ifacesMap[intf.Name] = intf
+		}
+	}
+
+	// merge interfaces
+	merged := make([]net.Interface, 0, len(ifacesMap))
+	for _, intf := range ifacesMap {
+		merged = append(merged, intf)
+	}
+	return merged
 }

--- a/server_unit_test.go
+++ b/server_unit_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -89,6 +90,87 @@ func TestServer_Recv_ProcessesPacket(t *testing.T) {
 	}
 }
 
+// testServer creates a Server with InterfaceManagers for testing.
+// This helper avoids direct struct construction with the removed ifaces field.
+func testServer(ipv4conn, ipv6conn api.PacketConn, ifaces []net.Interface) *Server {
+	return &Server{
+		ipv4conn:       ipv4conn,
+		ipv6conn:       ipv6conn,
+		ipv4Mgr:        NewInterfaceManager(ifaces, nil),
+		ipv6Mgr:        NewInterfaceManager(ifaces, nil),
+		provider:       NewInterfaceProvider(),
+		shouldShutdown: make(chan struct{}),
+		ttl:            3200,
+	}
+}
+
+// TestServer_InterfaceDisconnect_StopsSendingToFailedInterface verifies that when
+// a network interface disconnects during multicast response, the server stops
+// attempting to send to that interface. This is the server-side fix for the
+// infinite warning log issue.
+func TestServer_InterfaceDisconnect_StopsSendingToFailedInterface(t *testing.T) {
+	mockIPv4 := mocks.NewMockPacketConn(t)
+
+	// Two interfaces: eth0 (will fail) and wlan0 (stays healthy)
+	ifaces := []net.Interface{
+		{Index: 1, Name: "eth0"},
+		{Index: 2, Name: "wlan0"},
+	}
+
+	// Track calls per interface
+	var mu sync.Mutex
+	callsToEth0 := 0
+	callsToWlan0 := 0
+
+	// eth0 (index 1) returns ENETDOWN, wlan0 (index 2) succeeds
+	mockIPv4.EXPECT().WriteTo(mock.Anything, mock.AnythingOfType("int"), mock.Anything).RunAndReturn(
+		func(b []byte, ifIndex int, dst net.Addr) (int, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			if ifIndex == 1 {
+				callsToEth0++
+				return 0, syscall.ENETDOWN
+			}
+			callsToWlan0++
+			return len(b), nil
+		}).Maybe()
+
+	s := testServer(mockIPv4, nil, ifaces)
+
+	msg := new(dns.Msg)
+	msg.SetQuestion("_test._tcp.local.", dns.TypePTR)
+
+	// First multicast: both interfaces attempted
+	_ = s.multicastResponse(msg, 0)
+
+	mu.Lock()
+	firstEth0 := callsToEth0
+	firstWlan0 := callsToWlan0
+	mu.Unlock()
+
+	if firstEth0 != 1 || firstWlan0 != 1 {
+		t.Errorf("First response: expected 1 call each, got eth0=%d wlan0=%d", firstEth0, firstWlan0)
+	}
+
+	// Second multicast: eth0 should be excluded
+	_ = s.multicastResponse(msg, 0)
+
+	mu.Lock()
+	secondEth0 := callsToEth0
+	secondWlan0 := callsToWlan0
+	mu.Unlock()
+
+	if secondEth0 != 1 {
+		t.Errorf("Second response: eth0 should NOT be called again, got %d total calls", secondEth0)
+	}
+	if secondWlan0 != 2 {
+		t.Errorf("Second response: wlan0 should have 2 calls, got %d", secondWlan0)
+	}
+
+	t.Logf("SUCCESS: Server stops sending to disconnected interface")
+	t.Logf("eth0 calls: %d, wlan0 calls: %d", secondEth0, secondWlan0)
+}
+
 // TestServer_MulticastResponse_WritesToConnections verifies multicast sends to both connections
 func TestServer_MulticastResponse_WritesToConnections(t *testing.T) {
 	mockIPv4 := mocks.NewMockPacketConn(t)
@@ -100,13 +182,7 @@ func TestServer_MulticastResponse_WritesToConnections(t *testing.T) {
 	mockIPv4.EXPECT().WriteTo(mock.Anything, 1, mock.Anything).Return(0, nil).Once()
 	mockIPv6.EXPECT().WriteTo(mock.Anything, 1, mock.Anything).Return(0, nil).Once()
 
-	s := &Server{
-		ipv4conn:       mockIPv4,
-		ipv6conn:       mockIPv6,
-		ifaces:         []net.Interface{iface},
-		shouldShutdown: make(chan struct{}),
-		ttl:            3200,
-	}
+	s := testServer(mockIPv4, mockIPv6, []net.Interface{iface})
 
 	msg := new(dns.Msg)
 	msg.SetQuestion("_test._tcp.local.", dns.TypePTR)
@@ -126,13 +202,7 @@ func TestServer_MulticastResponse_SpecificInterface(t *testing.T) {
 	mockIPv4.EXPECT().WriteTo(mock.Anything, 2, mock.Anything).Return(0, nil).Once()
 	mockIPv6.EXPECT().WriteTo(mock.Anything, 2, mock.Anything).Return(0, nil).Once()
 
-	s := &Server{
-		ipv4conn:       mockIPv4,
-		ipv6conn:       mockIPv6,
-		ifaces:         []net.Interface{{Index: 1, Name: "eth0"}, {Index: 2, Name: "wlan0"}},
-		shouldShutdown: make(chan struct{}),
-		ttl:            3200,
-	}
+	s := testServer(mockIPv4, mockIPv6, []net.Interface{{Index: 1, Name: "eth0"}, {Index: 2, Name: "wlan0"}})
 
 	msg := new(dns.Msg)
 	msg.SetQuestion("_test._tcp.local.", dns.TypePTR)
@@ -155,14 +225,8 @@ func TestServer_Shutdown_ClosesConnections(t *testing.T) {
 	mockIPv4.EXPECT().Close().Return(nil).Once()
 	mockIPv6.EXPECT().Close().Return(nil).Once()
 
-	s := &Server{
-		ipv4conn:       mockIPv4,
-		ipv6conn:       mockIPv6,
-		ifaces:         []net.Interface{{Index: 1, Name: "eth0"}},
-		shouldShutdown: make(chan struct{}),
-		ttl:            3200,
-		service:        newServiceEntry("test", "_test._tcp", "local"),
-	}
+	s := testServer(mockIPv4, mockIPv6, []net.Interface{{Index: 1, Name: "eth0"}})
+	s.service = newServiceEntry("test", "_test._tcp", "local")
 	s.service.Port = 8080
 	s.service.HostName = "test.local."
 
@@ -578,14 +642,8 @@ func TestServer_SetText(t *testing.T) {
 		}).Maybe()
 	mockIPv6.EXPECT().WriteTo(mock.Anything, mock.Anything, mock.Anything).Return(0, nil).Maybe()
 
-	s := &Server{
-		ipv4conn:       mockIPv4,
-		ipv6conn:       mockIPv6,
-		ifaces:         []net.Interface{{Index: 1, Name: "eth0"}},
-		shouldShutdown: make(chan struct{}),
-		ttl:            3200,
-		service:        newServiceEntry("test", "_test._tcp", "local"),
-	}
+	s := testServer(mockIPv4, mockIPv6, []net.Interface{{Index: 1, Name: "eth0"}})
+	s.service = newServiceEntry("test", "_test._tcp", "local")
 	s.service.Port = 8080
 	s.service.HostName = "test.local."
 	s.service.Text = []string{"old=value"}
@@ -626,14 +684,8 @@ func TestServer_HandleQuery_RespondsToQueries(t *testing.T) {
 		}).Maybe()
 	mockIPv6.EXPECT().WriteTo(mock.Anything, mock.Anything, mock.Anything).Return(0, nil).Maybe()
 
-	s := &Server{
-		ipv4conn:       mockIPv4,
-		ipv6conn:       mockIPv6,
-		ifaces:         []net.Interface{{Index: 1, Name: "eth0"}},
-		shouldShutdown: make(chan struct{}),
-		ttl:            3200,
-		service:        newServiceEntry("myservice", "_http._tcp", "local"),
-	}
+	s := testServer(mockIPv4, mockIPv6, []net.Interface{{Index: 1, Name: "eth0"}})
+	s.service = newServiceEntry("myservice", "_http._tcp", "local")
 	s.service.Port = 8080
 	s.service.HostName = "myhost.local."
 	s.service.Text = []string{"key=value"}
@@ -691,14 +743,8 @@ func TestServer_UnicastResponse(t *testing.T) {
 			return len(b), nil
 		}).Once()
 
-	s := &Server{
-		ipv4conn:       mockIPv4,
-		ipv6conn:       nil,
-		ifaces:         []net.Interface{{Index: 1, Name: "eth0"}},
-		shouldShutdown: make(chan struct{}),
-		ttl:            3200,
-		service:        newServiceEntry("myservice", "_http._tcp", "local"),
-	}
+	s := testServer(mockIPv4, nil, []net.Interface{{Index: 1, Name: "eth0"}})
+	s.service = newServiceEntry("myservice", "_http._tcp", "local")
 	s.service.Port = 8080
 	s.service.HostName = "myhost.local."
 

--- a/server_unit_test.go
+++ b/server_unit_test.go
@@ -233,6 +233,77 @@ func TestServer_Shutdown_ClosesConnections(t *testing.T) {
 	s.Shutdown()
 }
 
+// TestServer_SyncInterfaces_JoinGroupSuccessActivates verifies syncInterfaces joins and activates.
+func TestServer_SyncInterfaces_JoinGroupSuccessActivates(t *testing.T) {
+	mockIPv4 := mocks.NewMockPacketConn(t)
+	mockProvider := mocks.NewMockInterfaceProvider(t)
+
+	iface := net.Interface{Index: 2, Name: "wlan0"}
+
+	mockProvider.EXPECT().MulticastInterfaces().Return([]net.Interface{iface}).Once()
+	mockIPv4.EXPECT().JoinGroup(mock.AnythingOfType("*net.Interface"), mock.Anything).RunAndReturn(
+		func(ifi *net.Interface, group net.Addr) error {
+			if ifi == nil || ifi.Index != iface.Index || ifi.Name != iface.Name {
+				t.Errorf("expected JoinGroup on %+v, got %+v", iface, ifi)
+			}
+			udpAddr, ok := group.(*net.UDPAddr)
+			if !ok || udpAddr == nil || !udpAddr.IP.Equal(mdnsGroupIPv4) {
+				t.Errorf("expected IPv4 group %v, got %v", mdnsGroupIPv4, group)
+			}
+			return nil
+		}).Once()
+
+	s := &Server{
+		ipv4conn:       mockIPv4,
+		ipv4Mgr:        NewInterfaceManager(nil, nil),
+		ipv6Mgr:        NewInterfaceManager(nil, nil),
+		provider:       mockProvider,
+		shouldShutdown: make(chan struct{}),
+		ttl:            3200,
+	}
+
+	s.syncInterfaces()
+
+	indices := s.ipv4Mgr.ActiveIndices()
+	if len(indices) != 1 || indices[0] != iface.Index {
+		t.Errorf("expected active indices [2], got %v", indices)
+	}
+}
+
+// TestServer_SyncInterfaces_JoinGroupFailureSetsBackoff verifies JoinGroup failure triggers backoff.
+func TestServer_SyncInterfaces_JoinGroupFailureSetsBackoff(t *testing.T) {
+	mockIPv6 := mocks.NewMockPacketConn(t)
+	mockProvider := mocks.NewMockInterfaceProvider(t)
+
+	iface := net.Interface{Index: 3, Name: "eth0"}
+
+	mockProvider.EXPECT().MulticastInterfaces().Return([]net.Interface{iface}).Once()
+	mockIPv6.EXPECT().JoinGroup(mock.AnythingOfType("*net.Interface"), mock.Anything).Return(syscall.ENETDOWN).Once()
+
+	s := &Server{
+		ipv6conn:       mockIPv6,
+		ipv4Mgr:        NewInterfaceManager(nil, nil),
+		ipv6Mgr:        NewInterfaceManager(nil, nil),
+		provider:       mockProvider,
+		shouldShutdown: make(chan struct{}),
+		ttl:            3200,
+	}
+
+	s.syncInterfaces()
+
+	indices := s.ipv6Mgr.ActiveIndices()
+	if len(indices) != 0 {
+		t.Errorf("expected no active indices after JoinGroup failure, got %v", indices)
+	}
+
+	s.ipv6Mgr.mu.RLock()
+	_, hasFailure := s.ipv6Mgr.failures[iface.Name]
+	s.ipv6Mgr.mu.RUnlock()
+	if !hasFailure {
+		t.Errorf("expected backoff failure state for %s", iface.Name)
+	}
+}
+
 // TestServerConfig verifies server configuration options
 func TestServerConfig(t *testing.T) {
 	t.Run("default TTL", func(t *testing.T) {

--- a/server_unit_test.go
+++ b/server_unit_test.go
@@ -901,3 +901,108 @@ func TestServer_UnicastResponse(t *testing.T) {
 		}
 	}
 }
+
+// helper function to extract interface names from a slice of net.Interface for easy lookup in tests
+func ifaceNames(ifaces []net.Interface) map[string]bool {
+	m := make(map[string]bool, len(ifaces))
+	for _, iface := range ifaces {
+		m[iface.Name] = true
+	}
+	return m
+}
+
+func TestMergeInterfaces_BothEmpty(t *testing.T) {
+	result := mergeInterfaces(nil, nil)
+	if len(result) != 0 {
+		t.Fatalf("expected empty result, got %d", len(result))
+	}
+}
+
+func TestMergeInterfaces_IPv4EmptyIPv6NotEmpty(t *testing.T) {
+	ipv6 := []net.Interface{
+		{Index: 1, Name: "eth0"},
+		{Index: 2, Name: "eth1"},
+	}
+	result := mergeInterfaces(nil, ipv6)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 interfaces, got %d", len(result))
+	}
+	names := ifaceNames(result)
+	if !names["eth0"] || !names["eth1"] {
+		t.Fatalf("expected eth0 and eth1, got %v", names)
+	}
+}
+
+func TestMergeInterfaces_IPv6EmptyIPv4NotEmpty(t *testing.T) {
+	ipv4 := []net.Interface{
+		{Index: 1, Name: "eth0"},
+		{Index: 2, Name: "eth1"},
+	}
+	result := mergeInterfaces(ipv4, nil)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 interfaces, got %d", len(result))
+	}
+	names := ifaceNames(result)
+	if !names["eth0"] || !names["eth1"] {
+		t.Fatalf("expected eth0 and eth1, got %v", names)
+	}
+}
+
+func TestMergeInterfaces_NoOverlap(t *testing.T) {
+	ipv4 := []net.Interface{
+		{Index: 5, Name: "eth1"},
+		{Index: 10, Name: "eth2"},
+	}
+	ipv6 := []net.Interface{
+		{Index: 1, Name: "lo"},
+		{Index: 3, Name: "wlan0"},
+	}
+	result := mergeInterfaces(ipv4, ipv6)
+	if len(result) != 4 {
+		t.Fatalf("expected 4 interfaces, got %d", len(result))
+	}
+	names := ifaceNames(result)
+	for _, expected := range []string{"lo", "wlan0", "eth1", "eth2"} {
+		if !names[expected] {
+			t.Fatalf("expected %s in result, got %v", expected, names)
+		}
+	}
+}
+
+func TestMergeInterfaces_PartialOverlap(t *testing.T) {
+	ipv4 := []net.Interface{
+		{Index: 1, Name: "eth0"},
+		{Index: 2, Name: "eth1"},
+	}
+	ipv6 := []net.Interface{
+		{Index: 2, Name: "eth1"},
+		{Index: 3, Name: "wlan0"},
+	}
+	result := mergeInterfaces(ipv4, ipv6)
+	if len(result) != 3 {
+		t.Fatalf("expected 3 interfaces, got %d", len(result))
+	}
+	names := ifaceNames(result)
+	if !names["eth0"] || !names["eth1"] || !names["wlan0"] {
+		t.Fatalf("expected eth0, eth1, wlan0, got %v", names)
+	}
+}
+
+func TestMergeInterfaces_FullOverlap(t *testing.T) {
+	ipv4 := []net.Interface{
+		{Index: 1, Name: "eth0"},
+		{Index: 2, Name: "wlan0"},
+	}
+	ipv6 := []net.Interface{
+		{Index: 1, Name: "eth0"},
+		{Index: 2, Name: "wlan0"},
+	}
+	result := mergeInterfaces(ipv4, ipv6)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 interfaces, got %d", len(result))
+	}
+	names := ifaceNames(result)
+	if !names["eth0"] || !names["wlan0"] {
+		t.Fatalf("expected eth0 and wlan0, got %v", names)
+	}
+}

--- a/server_unit_test.go
+++ b/server_unit_test.go
@@ -104,6 +104,64 @@ func testServer(ipv4conn, ipv6conn api.PacketConn, ifaces []net.Interface) *Serv
 	}
 }
 
+func TestServer_NewServer_IPv4AndIPv6Error(t *testing.T) {
+	ifaces := []net.Interface{{Index: 1, Name: "eth0"}}
+
+	mockFactory := mocks.NewMockConnectionFactory(t)
+	mockIPv4 := mocks.NewMockPacketConn(t)
+
+	mockFactory.EXPECT().CreateIPv4Conn(ifaces).Return(mockIPv4, nil).Once()
+	mockFactory.EXPECT().CreateIPv6Conn(ifaces).Return(nil, errors.New("IPv6 unavailable")).Once()
+
+	s, err := newServer(ifaces, applyServerOpts(WithServerConnFactory(mockFactory)))
+	if err != nil {
+		t.Fatalf("newServer failed: %v", err)
+	}
+	if s.ipv4conn != mockIPv4 {
+		t.Fatalf("expected IPv4 connection to be set")
+	}
+	if s.ipv6conn != nil {
+		t.Fatalf("expected IPv6 connection to be nil")
+	}
+}
+
+func TestServer_NewServer_IPv6AndIPv4Error(t *testing.T) {
+	ifaces := []net.Interface{{Index: 1, Name: "eth0"}}
+
+	mockFactory := mocks.NewMockConnectionFactory(t)
+	mockIPv6 := mocks.NewMockPacketConn(t)
+
+	mockFactory.EXPECT().CreateIPv4Conn(ifaces).Return(nil, errors.New("IPv4 unavailable")).Once()
+	mockFactory.EXPECT().CreateIPv6Conn(ifaces).Return(mockIPv6, nil).Once()
+
+	s, err := newServer(ifaces, applyServerOpts(WithServerConnFactory(mockFactory)))
+	if err != nil {
+		t.Fatalf("newServer failed: %v", err)
+	}
+	if s.ipv4conn != nil {
+		t.Fatalf("expected IPv4 connection to be nil")
+	}
+	if s.ipv6conn != mockIPv6 {
+		t.Fatalf("expected IPv6 connection to be set")
+	}
+}
+
+func TestServer_NewServer_IPv4ErrorAndIPv6Error(t *testing.T) {
+	ifaces := []net.Interface{{Index: 1, Name: "eth0"}}
+
+	mockFactory := mocks.NewMockConnectionFactory(t)
+	mockFactory.EXPECT().CreateIPv4Conn(ifaces).Return(nil, errors.New("IPv4 unavailable")).Once()
+	mockFactory.EXPECT().CreateIPv6Conn(ifaces).Return(nil, errors.New("IPv6 unavailable")).Once()
+
+	s, err := newServer(ifaces, applyServerOpts(WithServerConnFactory(mockFactory)))
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if s != nil {
+		t.Fatalf("expected server to be nil on error")
+	}
+}
+
 // TestServer_InterfaceDisconnect_StopsSendingToFailedInterface verifies that when
 // a network interface disconnects during multicast response, the server stops
 // attempting to send to that interface. This is the server-side fix for the


### PR DESCRIPTION
This change fixes infinite warning logs when network interfaces disconnect
during mDNS operations. Previously, the code would continue attempting to
send to disconnected interfaces, generating warnings on every attempt.

Key changes:
- Add InterfaceManager to track active/failed interfaces with adaptive backoff
- Add error classification (isInterfaceGone) to detect interface failures
- Update Client and Server to use InterfaceManager for dynamic iteration
- Fix Windows conn wrappers to return errors instead of logging them
- Add integration tests that simulate the original disconnect scenario

The fix uses separate IPv4/IPv6 managers to prevent cross-protocol failure
cascades. When an interface fails with ENXIO, ENETDOWN, or similar errors,
it's immediately removed from the active set. Recovery is attempted with
adaptive backoff (1s, 5s, 30s) when interfaces reappear.

This required the PR https://github.com/enbility/zeroconf/pull/3
It fixes https://github.com/enbility/zeroconf/issues/1